### PR TITLE
Fetch latest build in case of multiple version-codes per version

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -38,7 +38,7 @@ async function processConfig(config: Config) {
       const variants = await getVariants(app.org, app.repo, app.version);
       const found =
         (config.options?.arch
-          ? variants.find((v) => v.arch === config.options?.arch)
+          ? variants.findLast((v) => v.arch === config.options?.arch)
           : undefined) ?? variants.find((v) => v.arch === "universal");
 
       if (!found) {


### PR DESCRIPTION
Hi! First of all, thanks for your work!

Sometimes apkmirror.com has more than one build per version. Imho it makes sense to fetch the most up to date one. For an example see the ovpn-connect app:
  https://www.apkmirror.com/apk/openvpn/openvpn-connect/openvpn-connect-3-4-0-release/

Best solution would probably be to include a functionality to handle version-codes. However, here's a quick fix to at least return the most up to date package.